### PR TITLE
Filter update

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -6,26 +6,30 @@ import QueryResult from "./QueryResult";
 
 function App() {
   const [queryData, setQueryData] = useState([]);
+  const [loading, setLoading] = useState(false);
 
-  const handleSetQueryData = useCallback(
-    (data) =>
-      setQueryData(() => {
-        const copy = [...data];
-        copy.forEach((record) => {
-          record.value = record.calculated_value;
-          delete record.calculated_value;
-        });
-        return copy;
-      }),
-    [],
-  );
+  const handleSetLoading = useCallback((value) => {
+    setLoading(value);
+  }, []);
+
+  const handleSetQueryData = useCallback((data) => {
+    const copy = [...data];
+    copy.forEach((record) => {
+      record.value = record.calculated_value;
+      delete record.calculated_value;
+    });
+    setQueryData(copy);
+  }, []);
 
   return (
-    <div className="flex flex-col justify-between h-full p-10">
-      <header>DataLoaf</header>
-      <main className="flex flex-1 px-20 py-10 h-full">
-        <QueryBuilder handleSetQueryData={handleSetQueryData} />
-        <QueryResult queryData={queryData} />
+    <div className="flex flex-col justify-between h-full p-10 bg-base-100">
+      <header className="border-b border-b-neutral-600 pb-10">DataLoaf</header>
+      <main className="flex flex-1 px-20  h-full">
+        <QueryBuilder
+          handleSetQueryData={handleSetQueryData}
+          handleSetLoading={handleSetLoading}
+        />
+        <QueryResult queryData={queryData} loading={loading} />
       </main>
       <footer>Copyright stuff 2024</footer>
     </div>

--- a/src/components/FilterDropdown.jsx
+++ b/src/components/FilterDropdown.jsx
@@ -16,7 +16,13 @@ export default function FilterDropDown({ items, handleSetFilter, filter }) {
       [attr]: value,
     };
 
-    handleSetFilter(newFilters);
+    if (attr in eventAttrData) {
+      handleSetFilter({ events: { ...newFilters } });
+    }
+
+    if (attr in userAttrData) {
+      handleSetFilter({ users: { ...newFilters } });
+    }
   };
 
   return (
@@ -34,14 +40,14 @@ export default function FilterDropDown({ items, handleSetFilter, filter }) {
           attrData={eventAttrData}
           attributes={Object.keys(eventAttrData)}
           handleSetFilter={handleSetFilter}
-          filter={filter}
+          filter={filter.events}
         />
         <FilterDropdownOptions
           type={"users"}
           attrData={userAttrData}
           attributes={Object.keys(userAttrData)}
           handleSetFilter={handleSetFilter}
-          filter={filter}
+          filter={filter.users}
         />
       </ul>
     </div>

--- a/src/components/QueryBuilder.jsx
+++ b/src/components/QueryBuilder.jsx
@@ -4,19 +4,18 @@ import Metric from "./Metric";
 import Filter from "./Filter";
 import DateRange from "./DateRange";
 
-export default function QueryBuilder({ handleSetQueryData }) {
+export default function QueryBuilder({ handleSetQueryData, handleSetLoading }) {
   const [selectedEvent, setSelectedEvent] = useState({});
   const [selectedAggregation, setSelectedAggregation] = useState({});
   const [filter, setFilter] = useState({ events: {}, users: {} });
   const [dateRange, setDateRange] = useState("3M");
-  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
     let source = axios.CancelToken.source();
 
     const performRequest = async () => {
-      setLoading(true);
+      handleSetLoading(true);
 
       try {
         const response = await axios.post(
@@ -40,11 +39,11 @@ export default function QueryBuilder({ handleSetQueryData }) {
         handleSetQueryData(data);
 
         if (isMounted) {
-          setLoading(false);
+          handleSetLoading(false);
         }
       } catch (error) {
         if (!axios.isCancel(error) && isMounted) {
-          setLoading(false);
+          handleSetLoading(false);
         }
       }
     };
@@ -66,6 +65,7 @@ export default function QueryBuilder({ handleSetQueryData }) {
     filter,
     dateRange,
     handleSetQueryData,
+    handleSetLoading,
   ]);
 
   const handleSetFilter = (newFilters) => {
@@ -104,7 +104,7 @@ export default function QueryBuilder({ handleSetQueryData }) {
   };
 
   return (
-    <section className="w-1/4 rounded-md border border-black shadow-2xl flex flex-col justify-start p-10 bg-base-100">
+    <section className="w-1/4 rounded-sm flex flex-col justify-start p-10 bg-base-100 border-r border-r-neutral-600">
       <article>
         <h2>Metric</h2>
         <Metric

--- a/src/components/QueryResult.jsx
+++ b/src/components/QueryResult.jsx
@@ -1,7 +1,15 @@
 import ResultGraph from "./ResultGraph";
 import ResultTable from "./ResultTable";
 
-export default function QueryResult({ queryData }) {
+export default function QueryResult({ queryData, loading }) {
+  if (loading) {
+    return (
+      <div className="m-auto">
+        <p className="loading loading-spinner loading-lg text-primary"></p>
+      </div>
+    );
+  }
+
   return (
     <>
       <ResultGraph queryData={queryData} />


### PR DESCRIPTION
Two important changes here. Previous `GET` requests to the backend for dynamic queries are now `POST`. This is required as the data we are fetching requires complex specification via a JSON object, which cannot be passed in a `GET`. The backend routes will reflect this.

Also, because the backend must be able to differentiate between user attributes and event attributes to filter correctly, a more robust structure is sent to the backend to provide this information:
- The new structure is effectively the same as what the frontend receives as well

```json
{
  "events": {
    "device": ["desktop", "mobile"],
  }
  "user": {
    "location": ["Boston"]
  }
}
```

Also, as  slight increases to loading times were noticed with filtering implemented, a loading spinner was added during the query. Other miscellaneous tailwind changes made they're way in.