### PR TITLE
Multiple charts

### DIFF
--- a/data/dates/ranges.json
+++ b/data/dates/ranges.json
@@ -3,7 +3,7 @@
   "predefined": [
     { "display": "Today", "unit": "hour", "previous": 24 },
     { "display": "7D", "unit": "day", "previous": 7 },
-    { "display": "30D", "unit": "day", "previous": 30 },
+    { "display": "4W", "unit": "week", "previous": 4 },
     { "display": "3M", "unit": "month", "previous": 3 },
     { "display": "6M", "unit": "month", "previous": 6 },
     { "display": "12M", "unit": "month", "previous": 12 }

--- a/src/components/QueryBuilder.jsx
+++ b/src/components/QueryBuilder.jsx
@@ -57,7 +57,7 @@ export default function QueryBuilder({ handleUpdateQueryState }) {
 
     const debounceRequests = (queryState) => {
       return new Promise((resolve) => {
-        // uses queryIds instead of keys of queryState to guarentee order in all JS versions
+        // uses queryIds instead of keys of queryState to guarantee order in all JS versions
         const checkValues = async () => {
           const allRequiredFieldsPresent = queryIds.every((queryId) => {
             return (

--- a/src/components/QueryResult.jsx
+++ b/src/components/QueryResult.jsx
@@ -1,6 +1,16 @@
+import { useState } from "react";
 import ResultGraph from "./ResultGraph";
+import AreaChartIcon from "./icons/AreaChart";
+import BarChartIcon from "./icons/BarChart";
+import LineChartIcon from "./icons/LineChart";
 
 export default function QueryResult({ queryData, isLoading }) {
+  const [chartType, setChartType] = useState({
+    line: true,
+    area: false,
+    bar: false,
+  });
+
   if (isLoading) {
     return (
       <div className="m-auto">
@@ -9,9 +19,52 @@ export default function QueryResult({ queryData, isLoading }) {
     );
   }
 
+  const handleSetChartType = (e) => {
+    if (!(e.target instanceof HTMLButtonElement)) return;
+
+    const chartTypeCopy = { ...chartType };
+
+    for (const chart in chartTypeCopy) {
+      if (e.target.dataset.chart === chart) {
+        chartTypeCopy[chart] = true;
+      } else {
+        chartTypeCopy[chart] = false;
+      }
+    }
+
+    setChartType(chartTypeCopy);
+  };
+
+  const stopPropagation = (e) => {
+    e.stopPropagation();
+  };
+
   return (
-    <>
-      <ResultGraph queryData={queryData} />
-    </>
+    <div className="w-full h-full">
+      <div className="mt-10 mb-2 m-auto flex flex-1 justify-between w-[80%]">
+        <h2 className="text-neutral-400 italic self-end">Result Window:</h2>
+        <fieldset onClick={handleSetChartType}>
+          <button
+            data-chart="line"
+            className={`${chartType.line ? "bg-base-300 text-primary font-semibold" : "text-neutral-400"} border-l border-y text-neutral-400 border-neutral-600 p-1 rounded-l w-16`}
+          >
+            <LineChartIcon />
+          </button>
+          <button
+            data-chart="area"
+            className={`${chartType.area ? "bg-base-300 text-primary font-semibold" : "text-neutral-400"} border border-neutral-600 text-neutral-400 p-1 w-16`}
+          >
+            <AreaChartIcon />
+          </button>
+          <button
+            data-chart="bar"
+            className={`${chartType.bar ? "bg-base-300 text-primary font-semibold" : "text-neutral-400"} border-r border-y border-neutral-600 text-neutral-400 p-1 rounded-r w-16`}
+          >
+            <BarChartIcon />
+          </button>
+        </fieldset>
+      </div>
+      <ResultGraph queryData={queryData} chartType={chartType} />
+    </div>
   );
 }

--- a/src/components/QueryResult.jsx
+++ b/src/components/QueryResult.jsx
@@ -35,10 +35,6 @@ export default function QueryResult({ queryData, isLoading }) {
     setChartType(chartTypeCopy);
   };
 
-  const stopPropagation = (e) => {
-    e.stopPropagation();
-  };
-
   return (
     <div className="w-full h-full">
       <div className="mt-10 mb-2 m-auto flex flex-1 justify-between w-[80%]">

--- a/src/components/ResultGraph.jsx
+++ b/src/components/ResultGraph.jsx
@@ -1,7 +1,10 @@
-import React, { useRef } from "react";
 import {
   LineChart,
   Line,
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
   CartesianGrid,
   XAxis,
   YAxis,
@@ -18,14 +21,14 @@ const CustomTooltip = ({ active, payload, label, aggregationType }) => {
         style={{
           padding: "5px",
           borderRadius: "0.375rem",
-          backgroundColor: "rgba(255, 255, 255, 0.9)",
+          backgroundColor: "rgba(50, 50, 50, 0.90)",
           boxShadow: "0px 0px 10px rgba(0, 0, 0, 0.1)",
-          color: "black",
         }}
       >
         <p>{`${label}`}</p>
         {payload.map((item, index) => (
           <p
+            style={{ color: item.color }}
             key={index}
           >{`Query ${index + 1} ${aggregationType}: ${item.value}`}</p>
         ))}
@@ -34,8 +37,13 @@ const CustomTooltip = ({ active, payload, label, aggregationType }) => {
   }
 };
 
-const Graph = ({ queryData }) => {
-  const parentRef = useRef(null);
+const Graph = ({ queryData, chartType }) => {
+  console.log(queryData);
+  const colorMap = [
+    "#F1D492", // Similar to the provided color
+    "#FFA200", // Brighter orange
+    "#ff6000", // Darker orange
+  ];
 
   const timeUnit = queryData[0].timeUnit;
 
@@ -49,41 +57,41 @@ const Graph = ({ queryData }) => {
     return formattedValues;
   };
 
-  const colorMap = [
-    "#F1D492", // Similar to the provided color
-    "#FFA200", // Brighter orange
-    "#ff6000", // Darker orange
-  ];
+  let CurrentChart;
+  let CurrentChartItem;
+
+  switch (true) {
+    case chartType.line:
+      CurrentChart = LineChart;
+      CurrentChartItem = Line;
+      break;
+    case chartType.bar:
+      CurrentChart = BarChart;
+      CurrentChartItem = Bar;
+      break;
+    case chartType.area:
+      CurrentChart = AreaChart;
+      CurrentChartItem = Area;
+      break;
+  }
 
   return (
     <ResponsiveContainer
-      width="60%"
+      width="80%"
       minWidth="1000px"
-      height="65%"
-      minHeight="700px"
-      style={{ paddingTop: "2.5rem" }}
-      ref={parentRef}
+      height="70%"
+      minHeight="600px"
       className="mx-auto"
     >
-      <div textAnchor="middle" dominantBaseline="central">
-        <div
-          style={{
-            color: "rgb(115 115 115)",
-            fontStyle: "italic",
-          }}
-        >
-          Result Window
-        </div>
-      </div>
-      <LineChart
+      <CurrentChart
         style={{
           backgroundColor:
             "var(--fallback-b3, oklch(var(--b3) / var(--tw-bg-opacity)))",
           borderRadius: "0.375rem",
           padding: "2rem",
-          marginTop: "1rem",
           boxShadow: "0px 10px 25px -2px rgba(0,0,0,0.40)",
         }}
+        data={chartType.bar ? [] : null} // empty array workaround for known bar chart bug
       >
         <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
         <XAxis
@@ -93,6 +101,7 @@ const Graph = ({ queryData }) => {
         />
         <YAxis stroke="#ccc" dataKey={queryData.aggregationType} />
         <Tooltip
+          cursor={chartType.bar ? false : true}
           content={
             <CustomTooltip
               timeUnit={timeUnit}
@@ -102,19 +111,20 @@ const Graph = ({ queryData }) => {
         />
         {queryData.map((dataItem, index) => {
           return (
-            <Line
-              name={`Query${index + 1 > 1 ? ": " + Number(index + 1) + " " : ": "}${dataItem.aggregationType}`}
+            <CurrentChartItem
+              name={`Query${index + 1 > 1 ? " " + Number(index + 1) + ": " : ": "}${dataItem.aggregationType}`}
               key={index}
               type="monotone"
               dataKey={dataItem.aggregationType}
               data={formatQueryDataValues(dataItem)}
-              stroke={colorMap[index]} // random color
+              stroke={colorMap[index]}
+              fill={colorMap[index]}
             />
           );
         })}
         {/* show legend if any query data */}
         {queryData[0].values.length > 0 ? <Legend /> : null}{" "}
-      </LineChart>
+      </CurrentChart>
     </ResponsiveContainer>
   );
 };

--- a/src/components/ResultGraph.jsx
+++ b/src/components/ResultGraph.jsx
@@ -38,7 +38,6 @@ const CustomTooltip = ({ active, payload, label, aggregationType }) => {
 };
 
 const Graph = ({ queryData, chartType }) => {
-  console.log(queryData);
   const colorMap = [
     "#F1D492", // Similar to the provided color
     "#FFA200", // Brighter orange

--- a/src/components/icons/AreaChart.jsx
+++ b/src/components/icons/AreaChart.jsx
@@ -1,0 +1,20 @@
+export default function AreaChartIcon(props) {
+  return (
+    <svg
+      {...props}
+      className="pointer-events-none"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 3v18h18" />
+      <path d="M7 12v5h12V8l-5 5-4-4Z" />
+    </svg>
+  );
+}

--- a/src/components/icons/BarChart.jsx
+++ b/src/components/icons/BarChart.jsx
@@ -1,0 +1,21 @@
+export default function BarChartIcon(props) {
+  return (
+    <svg
+      {...props}
+      className="pointer-events-none"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="12" x2="12" y1="20" y2="10" />
+      <line x1="18" x2="18" y1="20" y2="4" />
+      <line x1="6" x2="6" y1="20" y2="16" />
+    </svg>
+  );
+}

--- a/src/components/icons/LineChart.jsx
+++ b/src/components/icons/LineChart.jsx
@@ -1,0 +1,20 @@
+export default function LineChartIcon(props) {
+  return (
+    <svg
+      {...props}
+      className="pointer-events-none"
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 3v18h18" />
+      <path d="m19 9-5 5-4-4-3 3" />
+    </svg>
+  );
+}


### PR DESCRIPTION
This adds the ability to select multiple charts for visualizations. The charts that it enables are line chart, area chart, and bar chart.

On like 95 of `ResultGraph`, there is a workaround to allow bar charts to render correctly when passing data directly to the bar instead of the chart. Normally, the bars will not render correctly, and it is a known issue, but passing an empty array fixes it, but there could be potential side effects, unknown.