### PR TITLE
route_update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.6.8",
         "dotenv": "^16.4.5",
+        "qs": "^6.12.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "recharts": "^2.12.3",
@@ -1709,7 +1710,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -2129,7 +2129,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -2293,7 +2292,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4"
       },
@@ -2305,7 +2303,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2975,7 +2972,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3020,7 +3016,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
@@ -3112,7 +3107,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -3148,7 +3142,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -3160,7 +3153,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3172,7 +3164,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3199,7 +3190,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4003,7 +3993,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4554,6 +4543,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4897,7 +4900,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -4950,7 +4952,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "axios": "^1.6.8",
     "dotenv": "^16.4.5",
-    "qs": "^6.12.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.12.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^1.6.8",
     "dotenv": "^16.4.5",
+    "qs": "^6.12.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.12.3",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -10,7 +10,7 @@ import Footer from "./Footer";
 function App() {
   const [queryState, dispatch] = useQueryReducer();
 
-  const handleUpdateQueryState = useCallback(
+  const handleUpdateQueryStatus = useCallback(
     ({ type, payload }) => {
       dispatch({ type, payload });
     },
@@ -21,7 +21,7 @@ function App() {
     <div className="flex flex-col justify-between h-full px-8 py-6 bg-base-100">
       <Header />
       <main className="overflow-auto flex flex-1 xl:items-start xl:justify-between items-center xl:flex-row flex-col px-20 h-full">
-        <QueryBuilder handleUpdateQueryState={handleUpdateQueryState} />
+        <QueryBuilder handleUpdateQueryStatus={handleUpdateQueryStatus} />
         <QueryResult
           queryData={queryState.data}
           isLoading={queryState.isLoading}

--- a/src/components/QueryBuilder.jsx
+++ b/src/components/QueryBuilder.jsx
@@ -5,7 +5,7 @@ import Query from "./Query";
 import QueryService from "../services/query";
 import DateRange from "./DateRange";
 
-export default function QueryBuilder({ handleUpdateQueryState }) {
+export default function QueryBuilder({ handleUpdateQueryStatus }) {
   const [initialQueryId] = useState(uuidv4());
   const [queryIds, setQueryIds] = useState([initialQueryId]);
   const [selectedDateRange, setSelectedDateRange] = useState(
@@ -27,9 +27,9 @@ export default function QueryBuilder({ handleUpdateQueryState }) {
     const { signal } = controller;
 
     const performRequest = async (data) => {
-      handleUpdateQueryState({ type: "FETCH_START", loading: true });
+      handleUpdateQueryStatus({ type: "FETCH_START", loading: true });
 
-      const body = {
+      const params = {
         filters: data.filters,
         eventName: data.event.value === "all" ? null : data.event.value,
         aggregationType: data.aggregation.value,
@@ -48,11 +48,11 @@ export default function QueryBuilder({ handleUpdateQueryState }) {
       };
 
       try {
-        const data = QueryService.eventsBy(body, options);
+        const data = QueryService.eventsBy(params, options);
         return data;
       } catch (error) {
         if (!signal.aborted) {
-          handleUpdateQueryState({ type: "FETCH_ERROR", payload: error });
+          handleUpdateQueryStatus({ type: "FETCH_ERROR", payload: error });
         }
         console.error(error);
       }
@@ -96,9 +96,9 @@ export default function QueryBuilder({ handleUpdateQueryState }) {
     const fetchData = async () => {
       try {
         const queryData = await debounceRequests(queryState);
-        handleUpdateQueryState({ type: "FETCH_SUCCESS", payload: queryData });
+        handleUpdateQueryStatus({ type: "FETCH_SUCCESS", payload: queryData });
       } catch (error) {
-        handleUpdateQueryState({ type: "FETCH_ERROR", payload: error });
+        handleUpdateQueryStatus({ type: "FETCH_ERROR", payload: error });
         console.error(error);
       }
     };
@@ -110,7 +110,7 @@ export default function QueryBuilder({ handleUpdateQueryState }) {
       controller.abort(); // Abort ongoing calls if new one is made
       controller = new AbortController(); // Reset controller for future requests
     };
-  }, [selectedDateRange, handleUpdateQueryState, queryState]);
+  }, [selectedDateRange, handleUpdateQueryStatus, queryState]);
   /* eslint-enable react-hooks/exhaustive-deps */
 
   const handleSetSelectedDateRange = (e) => {

--- a/src/services/query.js
+++ b/src/services/query.js
@@ -1,11 +1,10 @@
 import axios from "axios";
 
-async function eventsBy(body, options) {
-  const response = await axios.post(
-    `/api/query/${body.category}`,
-    body,
-    options,
-  );
+async function eventsBy(params, options) {
+  const response = await axios.get(`/api/query/${params.category}`, {
+    params,
+    ...options,
+  });
 
   return response.data;
 }


### PR DESCRIPTION
This changes the request method for analytics queries from `POST` to `GET`. Originally, these were made `POST` requests because there is a lot of data sent to the backend, which that required nested objects. `axios` does support url encoding of nested objects, but we could not find a way to decode properly. However, it was later found that the `qs` package does support this, meaning we can decode the `GET` requests on the backend properly, allowing us to use `GET`.